### PR TITLE
BUILDENV: After upgrade activemq-amq deploy changed name to broker-amq

### DIFF
--- a/devops/openshift/pipeline-demo-deploy.yaml
+++ b/devops/openshift/pipeline-demo-deploy.yaml
@@ -96,7 +96,7 @@ spec:
                   )
                   // purge AMQ quques
                   sh (
-                    script: "oc rsh \$(oc get pods | grep activemq-amq- | grep Running | awk \'{ print \$1 }\')  /opt/amq/bin/activemq purge",
+                    script: "oc rsh \$(oc get pods | grep broker-amq- | grep Running | awk \'{ print \$1 }\')  /opt/amq/bin/activemq purge",
                     returnStatus: true
                   )
                 }

--- a/devops/openshift/pipeline-housekeeping.yaml
+++ b/devops/openshift/pipeline-housekeeping.yaml
@@ -83,7 +83,7 @@ items:
                 steps {
                   script {
                     sh (
-                      script: "oc rsh \$(oc get pods | grep activemq-amq- | grep Running | awk \'{ print \$1 }\')  /opt/amq/bin/activemq purge",
+                      script: "oc rsh \$(oc get pods | grep broker-amq- | grep Running | awk \'{ print \$1 }\')  /opt/amq/bin/activemq purge",
                       returnStatus: true
                     )
                   }


### PR DESCRIPTION
Purge av köer fungerade inte efter OCP uppgradering.